### PR TITLE
Feat: PaperCard 눌렀을 때 ModalCard가 Mount되는 기능 추가

### DIFF
--- a/src/components/common/Card/ModalCard.jsx
+++ b/src/components/common/Card/ModalCard.jsx
@@ -1,5 +1,78 @@
-export function ModalCard({ info }) {
-  return <div>
-    
-  </div>;
-}
+import styled from "styled-components";
+import { Profile, Info, Name, RelationShip, CreatedTime } from "./PaperCard";
+import { forwardRef } from "react";
+
+const Container = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 99px;
+  display: flex;
+  flex-direction: column;
+  width: 600px;
+  height: 476px;
+  padding: 39px 40px;
+  border-radius: 16px;
+  background-color: var(--white);
+`;
+
+const ProfileWrap = styled.div`
+  display: flex;
+  width: 100%;
+  height: 116px;
+`;
+
+const ContentBox = styled.div`
+  margin-top: 16px;
+  width: 520px;
+  height: 256px;
+  line-height: 28px;
+  font-family: ${({ font }) => font};
+  font-size: 18px;
+  overflow: auto;
+  color: var(--gray-500);
+`;
+
+export const Divider = styled.div`
+  width: 520px;
+  height: 1px;
+  margin-top: -16px;
+  border: 1px solid var(--gray-100);
+`;
+
+const Button = styled.button`
+  width: 120px;
+  height: 40px;
+  margin-top: 24px;
+  padding: 7px 16px;
+  border-radius: 6px;
+  background-color: var(--purple-500);
+  color: var(--white);
+`;
+
+const ModalCard = forwardRef(({ selectedCardInfo }, ref) => {
+  const { sender, profileImageURL, relationship, content, font, createdAt } =
+    selectedCardInfo;
+  const formattedDate = new Date(createdAt).toLocaleDateString();
+
+  return (
+    <Container ref={ref}>
+      <ProfileWrap>
+        <Profile src={profileImageURL} alt="profile image" />
+        <Info>
+          <Name>
+            From.<strong>{sender}</strong>
+          </Name>
+          <RelationShip rel={relationship}>{relationship}</RelationShip>
+        </Info>
+        <CreatedTime>{formattedDate}</CreatedTime>
+      </ProfileWrap>
+      <Divider />
+      <ContentBox font={font}>{content}</ContentBox>
+      <Button>확인</Button>
+    </Container>
+  );
+});
+
+export default ModalCard;

--- a/src/components/common/Card/ModalCard.jsx
+++ b/src/components/common/Card/ModalCard.jsx
@@ -1,15 +1,27 @@
 import styled from "styled-components";
-import { Profile, Info, Name, RelationShip, CreatedTime } from "./PaperCard";
+import parse from "html-react-parser";
 import { forwardRef } from "react";
+import { Profile, Info, Name, RelationShip } from "./PaperCard";
+
+const ModalBackground = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 99;
+  background-color: rgba(0, 0, 0, 0.3);
+`;
 
 const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 99px;
-  display: flex;
-  flex-direction: column;
+  z-index: 99;
   width: 600px;
   height: 476px;
   padding: 39px 40px;
@@ -19,8 +31,10 @@ const Container = styled.div`
 
 const ProfileWrap = styled.div`
   display: flex;
+  align-items: center;
   width: 100%;
-  height: 116px;
+  height: 100px;
+  gap: 16px;
 `;
 
 const ContentBox = styled.div`
@@ -30,18 +44,28 @@ const ContentBox = styled.div`
   line-height: 28px;
   font-family: ${({ font }) => font};
   font-size: 18px;
-  overflow: auto;
   color: var(--gray-500);
+  white-space: normal; /* 기본 줄바꿈 설정 */
+  overflow: auto; /* 내용이 height을 넘으면 스크롤이 생김 */
+  overflow-wrap: break-word; /* 긴 단어도 줄바꿈 */
 `;
-
-export const Divider = styled.div`
+const Divider = styled.div`
   width: 520px;
   height: 1px;
-  margin-top: -16px;
+  margin-top: 16px;
   border: 1px solid var(--gray-100);
 `;
 
+const CreatedTime = styled.div`
+  height: 18px;
+  font-size: 12px;
+  color: var(--gray-400);
+`;
+
 const Button = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 120px;
   height: 40px;
   margin-top: 24px;
@@ -49,29 +73,33 @@ const Button = styled.button`
   border-radius: 6px;
   background-color: var(--purple-500);
   color: var(--white);
+  cursor: pointer;
 `;
 
-const ModalCard = forwardRef(({ selectedCardInfo }, ref) => {
+//ModalCard는 함수형 컴포넌트이기 때문에 ref를 전달할 수 없음. forwardRef가 이를 가능하게 해줌.(Container(DOM) -> ModarCard -> ModalCardContainer)
+const ModalCard = forwardRef(({ selectedCardInfo, onClose }, ref) => {
   const { sender, profileImageURL, relationship, content, font, createdAt } =
     selectedCardInfo;
   const formattedDate = new Date(createdAt).toLocaleDateString();
 
   return (
-    <Container ref={ref}>
-      <ProfileWrap>
-        <Profile src={profileImageURL} alt="profile image" />
-        <Info>
-          <Name>
-            From.<strong>{sender}</strong>
-          </Name>
-          <RelationShip rel={relationship}>{relationship}</RelationShip>
-        </Info>
-        <CreatedTime>{formattedDate}</CreatedTime>
-      </ProfileWrap>
-      <Divider />
-      <ContentBox font={font}>{content}</ContentBox>
-      <Button>확인</Button>
-    </Container>
+    <ModalBackground>
+      <Container ref={ref}>
+        <ProfileWrap>
+          <Profile src={profileImageURL} alt="profile image" />
+          <Info>
+            <Name>
+              From.<strong>{sender}</strong>
+            </Name>
+            <RelationShip rel={relationship}>{relationship}</RelationShip>
+          </Info>
+          <CreatedTime>{formattedDate}</CreatedTime>
+        </ProfileWrap>
+        <Divider />
+        <ContentBox font={font}>{parse(content)}</ContentBox>
+        <Button onClick={() => onClose()}>확인</Button>
+      </Container>
+    </ModalBackground>
   );
 });
 

--- a/src/components/common/Card/PaperCard.jsx
+++ b/src/components/common/Card/PaperCard.jsx
@@ -17,7 +17,7 @@ export const Container = styled.div`
 export const ProfileWrap = styled.div`
   display: flex;
   width: 100%;
-  height: 100px;
+  height: 80px;
   gap: 14px;
 `;
 
@@ -35,9 +35,11 @@ export const Profile = styled.img`
 `;
 
 export const Info = styled.div`
+  margin-top: 3px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
+  flex-grow: 1;
 `;
 
 export const Name = styled.div`
@@ -55,11 +57,11 @@ export const ContentBox = styled.div`
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3; /* 최대 3줄 표시 */
   overflow: hidden;
+  overflow-wrap: break-word; /* 긴 단어도 줄바꿈 */
   text-overflow: ellipsis; /* 넘치는 부분을 ...으로 표시 */
-  height: 4.5em; /* 대략 3줄 높이 */
   line-height: 1.5em; /* 줄 높이 설정 */
+  white-space: normal; /* 텍스트 줄바꿈 허용 */
 `;
-
 export const CreatedTime = styled.div`
   position: absolute;
   left: 24px;

--- a/src/components/common/Card/PaperCard.jsx
+++ b/src/components/common/Card/PaperCard.jsx
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
-import parse from 'html-react-parser';
+import styled from "styled-components";
+import parse from "html-react-parser";
 
 export const Container = styled.div`
   position: relative;
@@ -11,6 +11,7 @@ export const Container = styled.div`
   padding: 28px 24px;
   border-radius: 16px;
   background-color: var(--white);
+  cursor: pointer;
 `;
 
 export const ProfileWrap = styled.div`
@@ -21,7 +22,6 @@ export const ProfileWrap = styled.div`
 `;
 
 export const Divider = styled.div`
-  float: left;
   width: 336px;
   height: 1px;
   margin-top: -16px;
@@ -80,23 +80,38 @@ export const RelationShip = styled.div`
   font-size: 14px;
   border-radius: 4px;
   padding: 0 8px;
-  color: ${({ rel }) => (rel === '가족' ? 'var(--green-500)' : rel === '동료' ? 'var(--purple-600)' : rel === '지인' ? 'var(--beige-500)' : 'var(--blue-500)')};
-  background-color: ${({ rel }) => (rel === '가족' ? 'var(--green-100)' : rel === '동료' ? 'var(--purple-100)' : rel === '지인' ? 'var(--beige-100)' : 'var(--blue-100)')};
+  color: ${({ rel }) =>
+    rel === "가족"
+      ? "var(--green-500)"
+      : rel === "동료"
+        ? "var(--purple-600)"
+        : rel === "지인"
+          ? "var(--beige-500)"
+          : "var(--blue-500)"};
+  background-color: ${({ rel }) =>
+    rel === "가족"
+      ? "var(--green-100)"
+      : rel === "동료"
+        ? "var(--purple-100)"
+        : rel === "지인"
+          ? "var(--beige-100)"
+          : "var(--blue-100)"};
 `;
 
-export function PaperCard({ message }) {
+export function PaperCard({ message, onClick }) {
   if (!message) return null;
 
-  const { content, createdAt, font, profileImageURL, relationship, name } = message;
+  const { sender, profileImageURL, relationship, content, font, createdAt } =
+    message;
 
   const formattedDate = new Date(createdAt).toLocaleDateString();
   return (
-    <Container>
+    <Container onClick={onClick}>
       <ProfileWrap>
         <Profile src={profileImageURL} alt="profile image" />
         <Info>
           <Name>
-            From.<strong>{name}</strong>
+            From.<strong>{sender}</strong>
           </Name>
           <RelationShip rel={relationship}>{relationship}</RelationShip>
         </Info>

--- a/src/containers/Modal/ModalCardContainer.jsx
+++ b/src/containers/Modal/ModalCardContainer.jsx
@@ -1,26 +1,32 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import ModalCard from "../../components/common/Card/ModalCard.jsx";
 
 function ModalCardContainer({ onClose, selectedCardInfo }) {
-  const cardRef = useRef();
+  const modalRef = useRef();
+
   useEffect(() => {
     function handleClickOutside(event) {
-      // modalRef가 정의된 요소 외부에서 클릭이 발생했는지 확인
+      // modalRef가 정의된 요소 외부에서 클릭이 발생할 경우 모달 닫기 기능.
       if (modalRef.current && !modalRef.current.contains(event.target)) {
         onClose();
       }
     }
-    // 마우스 버튼이 눌렸을 때 이벤트 감지
+    // 모달이 mount되면 전체 영역에 mousedown 이벤트리스너 달기.
     document.addEventListener("mousedown", handleClickOutside);
-    document.body.style.backgroundColor = "rgba(0, 0, 0, 0.2)";
 
+    // 모달이 unmount 되면 달아둔 mousedown 이벤트리스너 삭제
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
-      document.body.style.backgroundColor = "";
     };
-  }, [onClose]);
+  }, []);
 
-  return <ModalCard ref={cardRef} selectedCardInfo={selectedCardInfo} />;
+  return (
+    <ModalCard
+      ref={modalRef}
+      onClose={onClose}
+      selectedCardInfo={selectedCardInfo}
+    />
+  );
 }
 
 export default ModalCardContainer;

--- a/src/containers/Modal/ModalCardContainer.jsx
+++ b/src/containers/Modal/ModalCardContainer.jsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useRef, useState } from "react";
+import ModalCard from "../../components/common/Card/ModalCard.jsx";
+
+function ModalCardContainer({ onClose, selectedCardInfo }) {
+  const cardRef = useRef();
+  useEffect(() => {
+    function handleClickOutside(event) {
+      // modalRef가 정의된 요소 외부에서 클릭이 발생했는지 확인
+      if (modalRef.current && !modalRef.current.contains(event.target)) {
+        onClose();
+      }
+    }
+    // 마우스 버튼이 눌렸을 때 이벤트 감지
+    document.addEventListener("mousedown", handleClickOutside);
+    document.body.style.backgroundColor = "rgba(0, 0, 0, 0.2)";
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.body.style.backgroundColor = "";
+    };
+  }, [onClose]);
+
+  return <ModalCard ref={cardRef} selectedCardInfo={selectedCardInfo} />;
+}
+
+export default ModalCardContainer;

--- a/src/pages/post/PostDetailPage.jsx
+++ b/src/pages/post/PostDetailPage.jsx
@@ -35,19 +35,6 @@ function PostDetailPage() {
   const { recipient } = useGetRecipientById(id);
   const { messages, error: messagesError } = useGetMessagesByRecipientId(id);
 
-  const openModal = (cardInfo) => {
-    setIsModalOpen(true);
-    setSelectedCardInfo(cardInfo);
-  };
-  const closeModal = () => {
-    setIsModalOpen(false);
-    setSelectedCardInfo({});
-  };
-
-  useEffect(() => {
-    console.log("Modal Open State: ", isModalOpen);
-  }, [isModalOpen]);
-
   // 오류 및 로딩 처리
   if (messagesError) {
     return <p style={{ color: "red" }}>Error: {messagesError}</p>;
@@ -60,6 +47,15 @@ function PostDetailPage() {
   if (!messages) {
     return <p>Loading messages...</p>;
   }
+
+  const openModal = (cardInfo) => {
+    setIsModalOpen(true);
+    setSelectedCardInfo(cardInfo);
+  };
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setSelectedCardInfo({});
+  };
 
   return (
     <div>

--- a/src/pages/post/PostDetailPage.jsx
+++ b/src/pages/post/PostDetailPage.jsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { HeaderService } from "../../components/Header/HeaderService.jsx";
 import { AddCard } from "../../components/common/Card/AddCard.jsx";
@@ -8,6 +9,7 @@ import {
   useGetMessagesByRecipientId,
 } from "../../hooks/useGetRecipients.jsx";
 import HeaderContainer from "../../containers/Header/HeaderContainer.jsx";
+import ModalCardContainer from "../../containers/Modal/ModalCardContainer.jsx";
 
 const Container = styled.div`
   height: calc(100vh - 133px); // 헤더 제외 높이
@@ -27,11 +29,24 @@ const GridWrap = styled.div`
 
 function PostDetailPage() {
   const { id } = useParams();
-
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedCardInfo, setSelectedCardInfo] = useState({});
   // 커스텀 Hook을 활용하여 데이터 fetching을 보다 효율적으로 처리합니다.
   const { recipient } = useGetRecipientById(id);
   const { messages, error: messagesError } = useGetMessagesByRecipientId(id);
-  console.log(messages);
+
+  const openModal = (cardInfo) => {
+    setIsModalOpen(true);
+    setSelectedCardInfo(cardInfo);
+  };
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setSelectedCardInfo({});
+  };
+
+  useEffect(() => {
+    console.log("Modal Open State: ", isModalOpen);
+  }, [isModalOpen]);
 
   // 오류 및 로딩 처리
   if (messagesError) {
@@ -55,10 +70,20 @@ function PostDetailPage() {
           <AddCard id={id} />
           {/* message 배열의 길이만큼 PaperCard 생성 */}
           {messages.results.map((message) => (
-            <PaperCard key={message.id} message={message} />
+            <PaperCard
+              key={message.id}
+              message={message}
+              onClick={() => openModal(message)}
+            />
           ))}
         </GridWrap>
       </Container>
+      {isModalOpen && (
+        <ModalCardContainer
+          onClose={closeModal}
+          selectedCardInfo={selectedCardInfo}
+        ></ModalCardContainer>
+      )}
     </div>
   );
 }

--- a/src/pages/post/PostOptionPage.jsx
+++ b/src/pages/post/PostOptionPage.jsx
@@ -168,8 +168,6 @@ const PostOptionPage = () => {
           : null, // 이미지가 선택되지 않으면 null
       };
 
-      console.log(payload); // payload 확인
-
       try {
         const result = await addRecipient(payload); // 서버에 payload 전송
         const id = result.id; // 생성된 롤링페이퍼의 ID


### PR DESCRIPTION
## 추가한 로직
- PostDeatilPage에서 isModalOpen이 true일 때는 ModalCardContainer 컴포넌트를 렌더링하도록 했습니다.
- ModalCardContainer에서는 모달을 닫는 onClose 함수와 클릭한 PaperCard에 대한 정보가 담긴 selectedCardInfo를 props로 받아 ModalCard를 렌더링합니다.
- 사용자가 ModalCard의 바깥 영역을 클릭할 경우 모달이 닫혀야 하기 때문에, ModalCard에서 useRef를 사용해 mousedown.target과 비교하여 onClose()함수가 동작하도록 하였습니다. 

## 새로 추가된 파일
- /d containers -> /d Modal -> ModalCardContainer.jsx 
- /d components -> /d Card -> ModalCard.jsx

## 🚀 트러블슈팅
- ModalCard에 ref를 전달하던 중 함수형 컴포넌트는 기존에 ref를 전달할 수 없다고 합니다. 이를 가능하게 해주는게 forwardRef라고 하여 ModalCard를 forwardRef로 감싸준 모습입니다. 
<img width="1113" alt="스크린샷 2024-08-29 오후 8 42 03" src="https://github.com/user-attachments/assets/9a0bf7ea-d354-40cc-8399-dcf794ef3f06">


## 스크린샷
<img width="1710" alt="스크린샷 2024-08-29 오후 8 10 21" src="https://github.com/user-attachments/assets/8fd0a3f2-d4f4-4646-8eba-efaf58d33b30">
