### PR TITLE
Feat: post/edit 페이지 삭제기능 추가

### DIFF
--- a/src/pages/post/PostDetailPage.jsx
+++ b/src/pages/post/PostDetailPage.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { HeaderService } from "../../components/Header/HeaderService.jsx";
 import { AddCard } from "../../components/common/Card/AddCard.jsx";
@@ -10,7 +10,7 @@ import {
 } from "../../hooks/useGetRecipients.jsx";
 import HeaderContainer from "../../containers/Header/HeaderContainer.jsx";
 import ModalCardContainer from "../../containers/Modal/ModalCardContainer.jsx";
-import { DeleteButton } from "../../components/common/Button/DeleteButton";
+import { DeleteButtonContainer } from "../../containers/Post/DeleteButtonContainer.jsx";
 
 const Container = styled.div`
   position: relative;
@@ -76,7 +76,7 @@ const PostDetailPage = ({ isEdit }) => {
             />
           ))}
         </GridWrap>
-        {isEdit && <DeleteButton />}
+        {isEdit && <DeleteButtonContainer selectedPaperId={recipient.id} />}
       </Container>
       {isModalOpen && (
         <ModalCardContainer


### PR DESCRIPTION
## 추가한 기능
- post페이지에서 각 카드의 휴지통버튼 눌렀을때 해당하는 카드가 삭제되는 기능
-> 삭제에 성공하면 edit 페이지로 이동함.

- post페이지에서 우측 상단에 있는 삭제하기 버튼 눌렀을 때 페이지 전체가 삭제되는 기능
-> 삭제에 성공하면 list 페이지로 이동함.

- edit 페이지에서는 AddCard가 작동이 안되게끔 설계 -> alert로 경고메세지 뜨게 함.

## 추가된 파일
-공통 컴포넌트 TrashCanButton, DeleteButton 추가함.

-디자인 컴포넌트를 리턴하기 이전에 DELETE axios 요청하는 비즈니스 로직이 있어 Container 폴더에 TrashCanButtonContainer, DeleteButtonContainer 파일 추가함.
