### PR TITLE
Fix: 리스트 페이지 페이지네이션 무한스크롤 버그 수정

### DIFF
--- a/src/containers/List/CommonListDetail.jsx
+++ b/src/containers/List/CommonListDetail.jsx
@@ -225,7 +225,7 @@ export default function CommonListDetail() {
       <ListSection>
         <Container>
           <Title>인기 롤링 페이퍼 🔥</Title>
-          <CardList loading={loading} messages={sortedPopularMessages} handleCardClick={handleCardClick} />
+          <CardList loading={loading} messages={popularMessagesToDisplay} handleCardClick={handleCardClick} />
           <Title>최근에 만든 롤링 페이퍼 ⭐️</Title>
           <CardList loading={loading} messages={sortedRecentMessages} handleCardClick={handleCardClick} />
         </Container>

--- a/src/containers/List/CommonListDetail.jsx
+++ b/src/containers/List/CommonListDetail.jsx
@@ -146,7 +146,7 @@ export default function CommonListDetail() {
   const fetchUser = async () => {
     setLoading(true);
     try {
-      const limit = 100;
+      const limit = 10;
       const users = await getAllUser({ limit, offset });
       const { results, ...data } = users;
 

--- a/src/containers/List/CommonListDetail.jsx
+++ b/src/containers/List/CommonListDetail.jsx
@@ -137,97 +137,71 @@ const MarginWrap = styled.div`
 `
 
 export default function CommonListDetail() {
-	const [loading, setLoading] = useState(false);
-  const [popularMessages, setPopularMessages] = useState([]);
-  const [recentMessages, setRecentMessages] = useState([]);
-  const [hasMorePopular, setHasMorePopular] = useState(true);
-  const [hasMoreRecent, setHasMoreRecent] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [allMessages, setAllMessages] = useState([]); // 모든 메시지를 저장할 상태
   const navigate = useNavigate();
 
-	const fetchPopularUsers = async () => {
+  // 데이터를 한번만 불러오는 함수
+  const fetchAllUsers = async () => {
     setLoading(true);
     try {
-      const limit = 20;
-      const users = await getAllUser({ limit, offset: 0 }); // 인기 리스트의 경우 offset을 0으로 고정
-      const { results, ...data } = users;
+      const limit = 20; // limit을 20으로 설정 (인기와 최근 데이터)
+      const users = await getAllUser({ limit, offset: 0 });
+      const { results } = users;
 
-			const filteredResults = results.filter(
-				(message) => new Date(message.createdAt) > new Date('2024-08-24') // 특정 날짜 이후의 데이터만 가져옴
-			);
-
-      setPopularMessages((prev) => {
-        const newMessages = filteredResults.filter(
-					(newMessage) => !prev.some((prevMessage) => prevMessage.id === newMessage.id)
-				);
-        return [...prev, ...newMessages];
-      });
-
-      setHasMorePopular(data !== null);
-    } catch (error) {
-      console.error("Failed to fetch popular users:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-	const fetchRecentUsers = async () => {
-    setLoading(true);
-    try {
-      const limit = 20;
-      const users = await getAllUser({ limit, offset: 0 }); // 최근 리스트는 limit을 20으로 설정
-      const { results, ...data } = users;
-
-			const filteredResults = results.filter(
+      // 특정 날짜 이후의 데이터만 필터링
+      const filteredResults = results.filter(
         (message) => new Date(message.createdAt) > new Date('2024-08-24')
       );
 
-      setRecentMessages((prev) => {
-        const newMessages = filteredResults.filter(
-					(newMessage) => !prev.some((prevMessage) => prevMessage.id === newMessage.id)
-				);
-        return [...prev, ...newMessages];
-      });
-
-      setHasMoreRecent(data !== null);
+      setAllMessages(filteredResults); // 필터링된 데이터를 저장
     } catch (error) {
-      console.error("Failed to fetch recent users:", error);
+      console.error("Failed to fetch users:", error);
     } finally {
       setLoading(false);
     }
   };
 
   useEffect(() => {
-    if (hasMorePopular) {
-      fetchPopularUsers();
-    }
-    if (hasMoreRecent) {
-      fetchRecentUsers();
-    }
+    fetchAllUsers(); // 컴포넌트가 마운트될 때 데이터 로드
   }, []);
 
-	const handleCardClick = (recipientId) => {
+  const handleCardClick = (recipientId) => {
     navigate(`/post/${recipientId}`);
   };
 
-	// 인기 롤링 페이퍼는 messageCount에 따라 정렬
-	const sortedPopularMessages = [...popularMessages].sort((a, b) => Number(b.messageCount) - Number(a.messageCount));
-	// **8개의 데이터만 화면에 표시**
-	const popularMessagesToDisplay = sortedPopularMessages.slice(0, 8);
-  // 최근에 만든 롤링 페이퍼는 createdAt에 따라 정렬
-  const sortedRecentMessages = [...recentMessages].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  // 메시지 카운트에 따라 인기 메시지 정렬
+  const sortedPopularMessages = [...allMessages].sort(
+    (a, b) => Number(b.messageCount) - Number(a.messageCount)
+  );
+  // 인기 메시지 중 상위 8개만 화면에 표시
+  const popularMessagesToDisplay = sortedPopularMessages.slice(0, 8);
+
+  // 생성 날짜에 따라 최근 메시지 정렬
+  const sortedRecentMessages = [...allMessages].sort(
+    (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
+  );
 
   const existingPath = true;
 
   return (
     <>
-			<Header existingPath={existingPath} />
+      <Header existingPath={existingPath} />
       <ScrollStyle />
       <ListSection>
         <Container>
           <Title>인기 롤링 페이퍼 🔥</Title>
-          <CardList loading={loading} messages={popularMessagesToDisplay} handleCardClick={handleCardClick} />
+          <CardList
+            loading={loading}
+            messages={popularMessagesToDisplay}
+            handleCardClick={handleCardClick}
+          />
           <Title>최근에 만든 롤링 페이퍼 ⭐️</Title>
-          <CardList loading={loading} messages={sortedRecentMessages} handleCardClick={handleCardClick} />
+          <CardList
+            loading={loading}
+            messages={sortedRecentMessages}
+            handleCardClick={handleCardClick}
+          />
         </Container>
         <GoToMakeButton to="/post">나도 만들어보기</GoToMakeButton>
       </ListSection>


### PR DESCRIPTION
### 변경사항

1.  리스트 페이지
1) 버그내용 
   - 인기롤링, 최근롤링이 둘 다 데이터를 100개씩 불러와서. 무한스크롤처럼 발생.
   - 인기롤링, 최근롤링이 똑같은 개수로 데이터를 불러옴.

2) 수정내용
   - 인기롤링은 8개까지만 불러와지도록 수정(2페이지까지).
   - 최근롤링은 최대 20개까지 불러와지도록 수정(5페이지까지).

***
### 스크린샷

![image](https://github.com/user-attachments/assets/d0ae4b75-b766-4a89-ae69-6918852fefb9)
